### PR TITLE
Fixed ZenPacks.Firestar.CiscoASA

### DIFF
--- a/ZenPacks.Firestar.CiscoASA/ZenPacks/Firestar/CiscoASA/objects/objects.xml
+++ b/ZenPacks.Firestar.CiscoASA/ZenPacks/Firestar/CiscoASA/objects/objects.xml
@@ -27122,20 +27122,4 @@ readonly
 </object>
 </tomanycont>
 </object>
-<property id='zendoc' type='string'>
-Cisco 5580-40 Adaptive Security Appliance
-</property>
-<property type="string" id="name" mode="w" >
-5580-40 ASA
-</property>
-<property type="lines" id="productKeys" mode="w" >
-['5580-40 ASA']
-</property>
-<property type="string" id="description" mode="w" >
-Cisco 5580-40 Adaptive Security Appliance
-</property>
-<property type="boolean" id="isOS" mode="w" >
-False
-</property>
-</object>
 </objects>

--- a/ZenPacks.Firestar.CiscoASA/setup.py
+++ b/ZenPacks.Firestar.CiscoASA/setup.py
@@ -15,7 +15,7 @@
 # These variables are overwritten by Zenoss when the ZenPack is exported
 # or saved.  Do not modify them directly here.
 NAME = 'ZenPacks.Firestar.CiscoASA'
-VERSION = '2.1.1'
+VERSION = '2.1.2'
 AUTHOR = 'Chris Morrison - chris.morrison@sita.aero, R.Esteve'
 LICENSE = ''
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.Firestar']


### PR DESCRIPTION
The objects.xml file for ZenPacks.Firestar.CiscoASA had some extra cruft at the tail end, which caused zenpack --install to fail (c.f. http://community.zenoss.org/docs/DOC-3465#comment-2468 ).

The lines removed were a duplicate fragment of lines 812-827.
